### PR TITLE
Support python 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 python:
+  - 2.6
   - 2.7
   - 3.3
   - 3.4

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ def install_libgit2(dirs):
     print('libgit2 cmake...')
     check_call(['cmake',
                 dirs.libgit2_src,
-                '-DCMAKE_INSTALL_PREFIX={}'.format(dirs.prefix),
+                '-DCMAKE_INSTALL_PREFIX={0}'.format(dirs.prefix),
                 '-DBUILD_CLAR=OFF'])
     print('libgit2 making...')
     check_call(['cmake', '--build', dirs.work_dir, '--target', 'install'])
@@ -69,7 +69,7 @@ def install_libgit2(dirs):
 def install_pygit2(dirs):
     """See http://www.pygit2.org/install.html"""
     os.environ['LIBGIT2'] = dirs.prefix
-    os.environ['LDFLAGS'] = "-Wl,-rpath='{}/lib',--enable-new-dtags {}".format(dirs.prefix, os.environ.get('LDFLAGS', ''))
+    os.environ['LDFLAGS'] = "-Wl,-rpath='{0}/lib',--enable-new-dtags {1}".format(dirs.prefix, os.environ.get('LDFLAGS', ''))
     script = os.path.join(dirs.pygit2_src, 'setup.py')
     os.chdir(dirs.pygit2_src)
     print('pygit2 clean...')


### PR DESCRIPTION
Hi, I'd like to ask you to accept this patch which makes venvgit2 compatible with Python 2.6. It's pretty straightforward and it shouldn't be very hard to maintain Python 2.6 compat (I'm willing to help with that even if you run into some problems in future).
Thanks for considering!